### PR TITLE
Small modification to repo URL to enable cloning vpngw again.

### DIFF
--- a/ansible/roles/scion_node/tasks/main.yml
+++ b/ansible/roles/scion_node/tasks/main.yml
@@ -29,7 +29,7 @@
        accept_hostkey=yes
   remote_user: scion
 - name: Checkout SCION VPN Gateway
-  git: repo=git@github.com:netsec-ethz/scion-vpngw.git
+  git: repo=ssh://git@github.com/netsec-ethz/scion-vpngw.git
        dest=~/scion-vpngw
        key_file=~/.ssh/deploy.scion-vpngw
        accept_hostkey=yes


### PR DESCRIPTION
The old URL to clone vpngw stopped working for the last couple of days with
an error saying:
fatal: could not read Username for 'https://github.com': No such device or address
The main SCION codebase can still be fetched the existing way. I suspect
the difference might be due to the vpngw repo being private.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-deploy/32)
<!-- Reviewable:end -->
