### PR TITLE
Explicitly specify state for directory creation in the basic role.

### DIFF
--- a/ansible/roles/basic/tasks/main.yml
+++ b/ansible/roles/basic/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Create ~root/.ssh and ensure permissions=0700
   file:
     path: ~root/.ssh
+    state: directory
     owner: root
     group: root
     mode: 0700
@@ -31,6 +32,7 @@
 - name: Create ~scion/.ssh and ensure permissions=0700
   file:
     path: ~scion/.ssh
+    state: directory
     owner: scion
     group: scion
     mode: 0700


### PR DESCRIPTION
Otherwise Ansible 2.0.2 will fail with an error message such as:
"msg": "file (/home/scion/.ssh) is absent, cannot continue"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-deploy/37)
<!-- Reviewable:end -->
